### PR TITLE
Fixed target calculation for units with a unitname with brackets

### DIFF
--- a/BMBattleReport/Constants/CommonCharacters.cs
+++ b/BMBattleReport/Constants/CommonCharacters.cs
@@ -1,4 +1,6 @@
-﻿namespace BMBattleReport.Constants
+﻿using System.Collections.Generic;
+
+namespace BMBattleReport.Constants
 {
     public class CommonCharacters
     {
@@ -6,7 +8,7 @@
         public const string WhiteSpace = " ";
         public const string Period = ".";
 
-        public const string HitsEnding = ")";
+        public static readonly List<string> HitsEnding = new() { "),", ")."};
         public const string OpeningParenthesis = "(";
         public const string TargetIndicator = " on ";
         public const string HitsInflictedIndicator = " hits";

--- a/BMBattleReport/Models/Noble.cs
+++ b/BMBattleReport/Models/Noble.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 
 namespace BMBattleReport.Models
 {
-    [DebuggerDisplay("{NobleName} from {Realm} with unit: {UnitName} - {UnitType}")]
+    [DebuggerDisplay("{NobleName} ({No}) from {Realm} with unit: {UnitName} - {UnitType}")]
     public class Noble
     {
         public string No { get; set; }

--- a/BMBattleReport/Services/HelperService.cs
+++ b/BMBattleReport/Services/HelperService.cs
@@ -1,13 +1,32 @@
 ﻿using BMBattleReport.Services.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace BMBattleReport.Services
 {
     public class HelperService : IHelperService
     {
-        public string GetSubstringMiddle(string source, string indexBegin, string indexEnd, bool includeIndexEnd = false)
+        public string GetSubstringMiddle(string source, string indexBegin, List<string> indexEnds, bool includeIndexEnd = false)
         {
             var firstIndex = source.IndexOf(indexBegin) + indexBegin.Length;
             
+            var adjustedSource = source[firstIndex..];
+
+            var (indexEnd, secondIndex) = indexEnds.Select(x => (x, adjustedSource.IndexOf(x))).Min();
+
+            if (secondIndex == -1)
+            {
+                return adjustedSource;
+            }
+
+            var substringEndIndex = includeIndexEnd ? secondIndex + indexEnd.Length : secondIndex;
+            return adjustedSource[..substringEndIndex];
+        }
+
+        public string GetSubstringMiddle(string source, string indexBegin, string indexEnd, bool includeIndexEnd = false)
+        {
+            var firstIndex = source.IndexOf(indexBegin) + indexBegin.Length;
+
             var adjustedSource = source[firstIndex..];
 
             var secondIndex = adjustedSource.IndexOf(indexEnd);
@@ -18,7 +37,7 @@ namespace BMBattleReport.Services
             }
 
             var substringEndIndex = includeIndexEnd ? secondIndex + indexEnd.Length : secondIndex;
-            return adjustedSource.Substring(0, substringEndIndex);
+            return adjustedSource[..substringEndIndex];
         }
 
         public string GetSubstringBeforeFirstOccurance(string source, string index)

--- a/BMBattleReport/Services/Interfaces/IHelperService.cs
+++ b/BMBattleReport/Services/Interfaces/IHelperService.cs
@@ -1,7 +1,10 @@
-﻿namespace BMBattleReport.Services.Interfaces
+﻿using System.Collections.Generic;
+
+namespace BMBattleReport.Services.Interfaces
 {
     public interface IHelperService
     {
+        string GetSubstringMiddle(string source, string indexBegin, List<string> indexEnd, bool includeIndexEnd = false);
         string GetSubstringMiddle(string source, string indexBegin, string indexEnd, bool includeIndexEnd = false);
         string GetSubstringBeforeFirstOccurance(string source, string index);
         string GetSubstringAfterLastOccurance(string source, string index);


### PR DESCRIPTION
Fixed the indexEnd element for calculating hits target to take either ), or ). instead of just the bracket. This way it'll only break if someone has a unit name with ), or ). at which point I say, 'kill'em'